### PR TITLE
Base58 encode request IDs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,12 +11,14 @@
       "dependencies": {
         "abort-controller": "^3.0.0",
         "ajv": "^8.3.0",
+        "bs58": "^4.0.1",
         "node-fetch": "^2.6.1",
         "tp-events": "^1.0.3"
       },
       "devDependencies": {
         "@jsdevtools/host-environment": "^2.1.2",
         "@jsdevtools/version-bump-prompt": "^6.1.0",
+        "@types/bs58": "^4.0.1",
         "@types/chai": "^4.2.16",
         "@types/mocha": "^8.2.2",
         "@types/node": "^14.14.37",
@@ -595,6 +597,15 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
+    "node_modules/@types/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-yfAgiWgVLjFCmRv8zAcOIHywYATEwiTVccTLnRp6UxTNavT55M9d/uhK3T03St/+8/z/wW+CRjGKUNmEqoHHCA==",
+      "dev": true,
+      "dependencies": {
+        "base-x": "^3.0.6"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "4.2.16",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.16.tgz",
@@ -1104,6 +1115,14 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "node_modules/base-x": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+      "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/base64-arraybuffer": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz",
@@ -1270,6 +1289,14 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
+      "dependencies": {
+        "base-x": "^3.0.2"
       }
     },
     "node_modules/buffer-from": {
@@ -1526,7 +1553,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -6830,8 +6856,7 @@
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -8504,6 +8529,15 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
+    "@types/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-yfAgiWgVLjFCmRv8zAcOIHywYATEwiTVccTLnRp6UxTNavT55M9d/uhK3T03St/+8/z/wW+CRjGKUNmEqoHHCA==",
+      "dev": true,
+      "requires": {
+        "base-x": "^3.0.6"
+      }
+    },
     "@types/chai": {
       "version": "4.2.16",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.16.tgz",
@@ -8926,6 +8960,14 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "base-x": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+      "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "base64-arraybuffer": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz",
@@ -9060,6 +9102,14 @@
         "electron-to-chromium": "^1.3.649",
         "escalade": "^3.1.1",
         "node-releases": "^1.1.70"
+      }
+    },
+    "bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
+      "requires": {
+        "base-x": "^3.0.2"
       }
     },
     "buffer-from": {
@@ -13485,8 +13535,7 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safer-buffer": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
   "devDependencies": {
     "@jsdevtools/host-environment": "^2.1.2",
     "@jsdevtools/version-bump-prompt": "^6.1.0",
+    "@types/bs58": "^4.0.1",
     "@types/chai": "^4.2.16",
     "@types/mocha": "^8.2.2",
     "@types/node": "^14.14.37",
@@ -95,6 +96,7 @@
   "dependencies": {
     "abort-controller": "^3.0.0",
     "ajv": "^8.3.0",
+    "bs58": "^4.0.1",
     "node-fetch": "^2.6.1",
     "tp-events": "^1.0.3"
   }

--- a/src/json-rpc/send-request.ts
+++ b/src/json-rpc/send-request.ts
@@ -9,7 +9,7 @@ import {
   getUserAgentString,
 } from "../isomorphic.node";
 import { processResponse } from "./process-response";
-import bs58 from "bs58";
+import * as bs58 from "bs58";
 
 const userAgent = getUserAgentString();
 
@@ -26,7 +26,8 @@ export async function sendRequest<TParams, TResult>(
 ): Promise<TResult> {
   // Generate a unique request ID using the timestamp and a random number
   const randomNumber = Math.floor(Math.random() * 1000);
-  const requestID = `req_` + bs58.encode(new Buffer(`${Date.now()}${randomNumber}`));
+  const seed = `${Date.now()}${randomNumber}`;
+  const requestID = `req_${bs58.encode(new Buffer(seed))}`;
 
   // Create an AbortController so we can cancel the request if it times out
   const controller = new AbortController();

--- a/src/json-rpc/send-request.ts
+++ b/src/json-rpc/send-request.ts
@@ -9,6 +9,7 @@ import {
   getUserAgentString,
 } from "../isomorphic.node";
 import { processResponse } from "./process-response";
+import bs58 from "bs58";
 
 const userAgent = getUserAgentString();
 
@@ -25,7 +26,7 @@ export async function sendRequest<TParams, TResult>(
 ): Promise<TResult> {
   // Generate a unique request ID using the timestamp and a random number
   const randomNumber = Math.floor(Math.random() * 1000);
-  const requestID = `req_${Date.now()}${randomNumber}`;
+  const requestID = `req_` + bs58.encode(new Buffer(`${Date.now()}${randomNumber}`));
 
   // Create an AbortController so we can cancel the request if it times out
   const controller = new AbortController();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,6 @@
     "strictBindCallApply": true,
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
-    "esModuleInterop": true,
     "stripInternal": true,
 
     "typeRoots": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
     "strictBindCallApply": true,
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
+    "esModuleInterop": true,
     "stripInternal": true,
 
     "typeRoots": [


### PR DESCRIPTION
In this PR, we update the request IDs sent from the SDK to be Base58 encoded. In the existing [Shipengine-API, we validate the request IDs](https://github.com/ShipEngine/shipengine-api/blob/main/lib/shipengine/core/requests.ex#L15) according to the Base58 spec and will return an error otherwise.

Note: I needed to add a flag to the [tsconfig](https://github.com/ShipEngine/shipengine-js/pull/116/files#diff-b55cdbef4907b7045f32cc5360d48d262cca5f94062e353089f189f4460039e0R22) to enable the [bs58](https://github.com/cryptocoinjs/bs58) library. Please let me know if this is not idiomatic or if there is an alternative library for Base58 encoding.