### PR TITLE
Dx 1260 test server side errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ based on the standards of the country in which the address resides.
 address cannot be normalized, an error is returned.
 * [`getCarrierAccounts`](./docs/get-carrier-accounts.md) - Returns a list of carrier accounts that have been connected through
 the [ShipEngine dashboard](https://www.shipengine.com/docs/carriers/setup/).
+* `clearCache` - Clear the SDK cache. Currently only stores carrier account data.
 
 Contributing
 --------------------------

--- a/src/carrier/account-cache.ts
+++ b/src/carrier/account-cache.ts
@@ -31,8 +31,15 @@ export function getAccountCache(carrierCode?: string): CarrierAccount[] {
  */
 export function setAccountCache(accounts: CarrierAccount[]): void {
   // Set the length to 0 to clear the cache
-  accountCache.length = 0;
+  clearAccountCache();
   for (const account of accounts) {
     accountCache.push(account);
   }
+}
+
+/**
+ * Clear Carrier account cache
+ */
+export function clearAccountCache(): void {
+  accountCache.length = 0;
 }

--- a/src/shipengine.ts
+++ b/src/shipengine.ts
@@ -11,6 +11,7 @@ import { CarrierAccount } from "./carrier/public-types";
 import { NormalizedConfig, ShipEngineConfig } from "./config";
 import { TrackingParams, TrackPackageResult } from "./track/public-types";
 import { trackPackage } from "./track/track-package";
+import { clearAccountCache } from "./carrier/account-cache";
 
 /**
  * Exposes the functionality of the ShipEngine API.
@@ -119,5 +120,12 @@ export class ShipEngine extends EventEmitter {
   ): Promise<TrackPackageResult> {
     const mergedConfig = NormalizedConfig.merge(this.config, config);
     return trackPackage(params, mergedConfig, this);
+  }
+
+  /**
+   * Clear the SDK Cache
+   */
+  public clearCache(): void {
+    clearAccountCache();
   }
 }

--- a/test/specs/get-carrier-accounts.spec.js
+++ b/test/specs/get-carrier-accounts.spec.js
@@ -3,8 +3,15 @@ const { ShipEngine } = require("../../");
 const { apiKey, baseURL } = require("../utils/constants");
 const errors = require("../utils/errors");
 
-describe("getCarrierAccounts()", async function () {
-  it("Returns an empty array if no accounts are setup yet", async function () {
+const { setAccountCache } = require("../../cjs/carrier/account-cache");
+
+describe("getCarrierAccounts()", async () => {
+  // Clear the carrier cache before each unit test to ensure no side effects get stored.
+  beforeEach(() => {
+    setAccountCache([]);
+  });
+
+  it("Returns an empty array if no accounts are setup yet", async () => {
     let response;
     const carrierName = "royal_mail";
 
@@ -18,7 +25,7 @@ describe("getCarrierAccounts()", async function () {
     expect(response).to.eql([]);
   });
 
-  it("Returns multiple accounts for different carriers", async function () {
+  it("Returns multiple accounts for different carriers", async () => {
     let accounts;
 
     const shipengine = new ShipEngine({ apiKey, baseURL });
@@ -47,7 +54,7 @@ describe("getCarrierAccounts()", async function () {
     assertAccountFormat(accounts);
   });
 
-  it("Returns multiple accounts for the same carrier", async function () {
+  it("Returns multiple accounts for the same carrier", async () => {
     let accounts;
     let carrierCode = "fedex";
 
@@ -60,7 +67,7 @@ describe("getCarrierAccounts()", async function () {
     }
 
     // The list contains the expected number of carrier accounts
-    expect(accounts).to.be.an("array").and.lengthOf(5);
+    expect(accounts).to.be.an("array").and.lengthOf(2);
 
     // The list contains the expected carrier accounts (IDs, names, account numbers, etc.)
     // All accounts have an account name
@@ -78,7 +85,7 @@ describe("getCarrierAccounts()", async function () {
   });
 
   // TODO This test fails when the suite is run but passes when run on its own
-  it.skip("Throws a server-side error", async function () {
+  it("Throws a server-side error", async () => {
     let carrierName = "access_worldwide";
 
     const shipengine = new ShipEngine({ apiKey, baseURL });
@@ -92,13 +99,14 @@ describe("getCarrierAccounts()", async function () {
         source: "shipengine",
         type: "system",
         code: "unspecified",
-        message: "Unable to connect to the database",
+        message:
+          "Unable to process this request. A downstream API error occurred.",
       });
       expect(error.requestID).to.match(/^req_\w+$/);
     }
   });
 
-  it("Throws an client-side error if an invalid carrierCode is passed", async function () {
+  it("Throws an client-side error if an invalid carrierCode is passed", async () => {
     let carrierName = "my_carrier";
 
     const shipengine = new ShipEngine({ apiKey, baseURL });
@@ -119,7 +127,7 @@ describe("getCarrierAccounts()", async function () {
   });
 
   // TODO This test fails when the suite is run but passes when run on its own
-  it.skip("Throws a server-side 429 error if the rate limit is exceeded", async function () {
+  it.skip("Throws a server-side 429 error if the rate limit is exceeded", async () => {
     // This case runs a little long for some reason
     this.timeout(15000);
 

--- a/test/specs/get-carrier-accounts.spec.js
+++ b/test/specs/get-carrier-accounts.spec.js
@@ -3,19 +3,15 @@ const { ShipEngine } = require("../../");
 const { apiKey, baseURL } = require("../utils/constants");
 const errors = require("../utils/errors");
 
-const { setAccountCache } = require("../../cjs/carrier/account-cache");
-
 describe("getCarrierAccounts()", async () => {
   // Clear the carrier cache before each unit test to ensure no side effects get stored.
-  beforeEach(() => {
-    setAccountCache([]);
-  });
 
   it("Returns an empty array if no accounts are setup yet", async () => {
     let response;
     const carrierName = "royal_mail";
 
     const shipengine = new ShipEngine({ apiKey, baseURL });
+    shipengine.clearCache();
 
     try {
       response = await shipengine.getCarrierAccounts(carrierName);
@@ -29,6 +25,7 @@ describe("getCarrierAccounts()", async () => {
     let accounts;
 
     const shipengine = new ShipEngine({ apiKey, baseURL });
+    shipengine.clearCache();
 
     try {
       accounts = await shipengine.getCarrierAccounts();
@@ -59,6 +56,7 @@ describe("getCarrierAccounts()", async () => {
     let carrierCode = "fedex";
 
     const shipengine = new ShipEngine({ apiKey, baseURL });
+    shipengine.clearCache();
 
     try {
       accounts = await shipengine.getCarrierAccounts(carrierCode);
@@ -89,6 +87,7 @@ describe("getCarrierAccounts()", async () => {
     let carrierName = "access_worldwide";
 
     const shipengine = new ShipEngine({ apiKey, baseURL });
+    shipengine.clearCache();
 
     try {
       await shipengine.getCarrierAccounts(carrierName);

--- a/test/specs/get-carrier-accounts.spec.js
+++ b/test/specs/get-carrier-accounts.spec.js
@@ -4,7 +4,6 @@ const { apiKey, baseURL } = require("../utils/constants");
 const errors = require("../utils/errors");
 
 describe("getCarrierAccounts()", async () => {
-
   it("Returns an empty array if no accounts are setup yet", async () => {
     let response;
     const carrierName = "royal_mail";

--- a/test/specs/get-carrier-accounts.spec.js
+++ b/test/specs/get-carrier-accounts.spec.js
@@ -4,7 +4,6 @@ const { apiKey, baseURL } = require("../utils/constants");
 const errors = require("../utils/errors");
 
 describe("getCarrierAccounts()", async () => {
-  // Clear the carrier cache before each unit test to ensure no side effects get stored.
 
   it("Returns an empty array if no accounts are setup yet", async () => {
     let response;
@@ -82,7 +81,6 @@ describe("getCarrierAccounts()", async () => {
     assertAccountFormat(accounts);
   });
 
-  // TODO This test fails when the suite is run but passes when run on its own
   it("Throws a server-side error", async () => {
     let carrierName = "access_worldwide";
 


### PR DESCRIPTION
https://auctane.atlassian.net/browse/DX-1260

This test was actually already written but wasn't passing because of caching issues that were specific to all the unit tests being run. While we new up a ShipEngine Client on each test suite the actual cache is stored in a [singleton](https://github.com/ShipEngine/shipengine-js/blob/38bb649aa7f5b567b72c7dfe35be7f6d1c0b9e8e/src/carrier/account-cache.ts#L6) that isn't tied to the new class instance so there already is a cache when there isn't expected to be one.

Since is a feature we want to expose to the end user, especially as we add more caching layers as the SDK gets developed, I added a top level `clearCache` method to the ShipEngine class with @JamesMessinger's blessing.