### PR TITLE
fix: use ignoreMinAndMaxItems option to prevent tuples

### DIFF
--- a/scripts/gen-types.js
+++ b/scripts/gen-types.js
@@ -2,45 +2,45 @@ const { compileFromFile } = require('json-schema-to-typescript');
 const fs = require('fs');
 
 // Validate Address
-compileFromFile('node_modules/shipengine-json-schema/requests/validate_address_request_body.json')
+compileFromFile('node_modules/shipengine-json-schema/requests/validate_address_request_body.json', {'ignoreMinAndMaxItems':true})
   .then(ts => fs.writeFileSync('src/validate-addresses/types/private-request.ts', ts))
 
-compileFromFile('node_modules/shipengine-json-schema/responses/validate_address_response_body.json')
+compileFromFile('node_modules/shipengine-json-schema/responses/validate_address_response_body.json', {'ignoreMinAndMaxItems':true})
   .then(ts => fs.writeFileSync('src/validate-addresses/types/private-response.ts', ts))
 
 // Create Label
-compileFromFile('node_modules/shipengine-json-schema/requests/create_label_request_body.json')
+compileFromFile('node_modules/shipengine-json-schema/requests/create_label_request_body.json', {'ignoreMinAndMaxItems':true})
   .then(ts => fs.writeFileSync('src/create-label-from-shipment-details/types/private-request.ts', ts))
 
-compileFromFile('node_modules/shipengine-json-schema/responses/create_label_response_body.json')
+compileFromFile('node_modules/shipengine-json-schema/responses/create_label_response_body.json', {'ignoreMinAndMaxItems':true})
   .then(ts => fs.writeFileSync('src/create-label-from-shipment-details/types/private-response.ts', ts))
 
 // Create Label By Rate ID
-compileFromFile('node_modules/shipengine-json-schema/requests/create_label_from_rate_request_body.json')
+compileFromFile('node_modules/shipengine-json-schema/requests/create_label_from_rate_request_body.json', {'ignoreMinAndMaxItems':true})
   .then(ts => fs.writeFileSync('src/create-label-from-rate/types/private-request.ts', ts))
 
-compileFromFile('node_modules/shipengine-json-schema/responses/create_label_from_rate_response_body.json')
+compileFromFile('node_modules/shipengine-json-schema/responses/create_label_from_rate_response_body.json', {'ignoreMinAndMaxItems':true})
   .then(ts => fs.writeFileSync('src/create-label-from-rate/types/private-response.ts', ts))
 
 // List Carrier Accounts
-compileFromFile('node_modules/shipengine-json-schema/responses/list_carriers_response_body.json')
+compileFromFile('node_modules/shipengine-json-schema/responses/list_carriers_response_body.json', {'ignoreMinAndMaxItems':true})
   .then(ts => fs.writeFileSync('src/list-carriers/types/private-response.ts', ts))
 
 // Get Rates
 compileFromFile('node_modules/shipengine-json-schema/requests/calculate_rates_request_body.json', {'ignoreMinAndMaxItems':true})
 .then(ts => fs.writeFileSync('src/get-rates-with-shipment-details/types/private-request.ts', ts))
 
-compileFromFile('node_modules/shipengine-json-schema/responses/calculate_rates_response_body.json')
+compileFromFile('node_modules/shipengine-json-schema/responses/calculate_rates_response_body.json', {'ignoreMinAndMaxItems':true})
 .then(ts => fs.writeFileSync('src/get-rates-with-shipment-details/types/private-response.ts', ts))
 
 // Track By Carrier Code and Tracking Number
-compileFromFile('node_modules/shipengine-json-schema/responses/get_tracking_log_response_body.json')
+compileFromFile('node_modules/shipengine-json-schema/responses/get_tracking_log_response_body.json', {'ignoreMinAndMaxItems':true})
   .then(ts => fs.writeFileSync('src/track-using-carrier-code-and-tracking-number/types/private-response.ts', ts))
 
 // Track Using Label ID
-compileFromFile('node_modules/shipengine-json-schema/responses/get_tracking_log_from_label_response_body.json')
+compileFromFile('node_modules/shipengine-json-schema/responses/get_tracking_log_from_label_response_body.json', {'ignoreMinAndMaxItems':true})
   .then(ts => fs.writeFileSync('src/track-using-label-id/types/private-response.ts', ts))
 
 // Void Label
-compileFromFile('node_modules/shipengine-json-schema/responses/void_label_response_body.json')
+compileFromFile('node_modules/shipengine-json-schema/responses/void_label_response_body.json', {'ignoreMinAndMaxItems':true})
   .then(ts => fs.writeFileSync('src/void-label-with-label-id/types/private-response.ts', ts))

--- a/scripts/gen-types.js
+++ b/scripts/gen-types.js
@@ -27,7 +27,7 @@ compileFromFile('node_modules/shipengine-json-schema/responses/list_carriers_res
   .then(ts => fs.writeFileSync('src/list-carriers/types/private-response.ts', ts))
 
 // Get Rates
-compileFromFile('node_modules/shipengine-json-schema/requests/calculate_rates_request_body.json')
+compileFromFile('node_modules/shipengine-json-schema/requests/calculate_rates_request_body.json', {'ignoreMinAndMaxItems':true})
 .then(ts => fs.writeFileSync('src/get-rates-with-shipment-details/types/private-request.ts', ts))
 
 compileFromFile('node_modules/shipengine-json-schema/responses/calculate_rates_response_body.json')

--- a/src/get-rates-with-shipment-details/types/private-request.ts
+++ b/src/get-rates-with-shipment-details/types/private-request.ts
@@ -127,7 +127,7 @@ export interface RateRequestOptions {
   [k: string]: unknown;
 }
 export interface RateRequestBody {
-  carrier_ids: [SeId, ...SeId[]];
+  carrier_ids: SeId[];
   package_types?: string[];
   service_codes?: string[];
   calculate_tax_amount?: boolean;
@@ -162,7 +162,7 @@ export interface PartialShipment {
   origin_type?: OriginType1;
   insurance_provider?: InsuranceProvider & string;
   order_source_code?: OrderSourceName1;
-  packages?: [Package, ...Package[]];
+  packages?: Package[];
 }
 export interface ShipmentItem {
   name?: string;

--- a/src/get-rates-with-shipment-details/types/private-response.ts
+++ b/src/get-rates-with-shipment-details/types/private-response.ts
@@ -220,7 +220,7 @@ export interface PartialShipment {
   insurance_provider?: InsuranceProvider & string;
   tags?: Tag[];
   order_source_code?: OrderSourceName1;
-  packages?: [Package, ...Package[]];
+  packages?: Package[];
   total_weight?: Weight2;
 }
 export interface ShipmentItem {

--- a/src/get-rates-with-shipment-details/types/public-params.ts
+++ b/src/get-rates-with-shipment-details/types/public-params.ts
@@ -380,7 +380,7 @@ interface ShippingAddress {
 }
 interface RateOptions {
   rateOptions: {
-    carrierIds: [string, ...string[]];
+    carrierIds: string[];
     packageTypes?: string[];
     serviceCodes?: string[];
     calculateTaxAmount?: boolean;


### PR DESCRIPTION
Fixes [183](https://github.com/ShipEngine/shipengine-js/issues/183)