### PR TITLE
fix: [SE-120] SDK Modifications / Improvements Thirty Madison

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,62 @@ const ShipEngine = require("shipengine");
 const shipengine = new ShipEngine("___YOUR_API_KEY_HERE__");
 
 ```
+
+Configuring the ShipEngine SDK
+-------------------------------
+* Be sure to configure the SDK if you would like to update things like `retries`, `timeouts`, and `page sizes` using the [`ShipEngine Config`](./src/config.ts) interface. Alternatively, you can simply pass in your ShipEngine API Key and use the default configuration.
+
+```TypeScript
+export interface ShipEngineConfig {
+  /**
+   * Your ShipEngine API key.
+   *
+   * This can be a production or sandbox key. Sandbox keys start with "TEST_".
+   */
+  apiKey: string;
+
+  /**
+   * ShipEngine child account API key (partner API)
+   *
+   * This can be a production or sandbox key. Sandbox keys start with "TEST_".
+   */
+  onBehalfOf?: string;
+
+  /**
+   * The URL of the ShipEngine API. You can usually leave this unset and it will
+   * default to our public API.
+   */
+  baseURL?: string | URL;
+
+  /**
+   * Some ShipEngine API endpoints return paged data. This lets you control the
+   * number of items returned per request. Larger numbers will use more memory
+   * but will require fewer HTTP requests.
+   *
+   * Defaults to 50.
+   */
+  pageSize?: number;
+
+  /**
+   * If the ShipEngine client receives a rate limit error it can automatically
+   * retry the request after a few seconds. This setting lets you control how
+   * many times it will retry before giving up.
+   *
+   * Defaults to 1, which means up to 2 attempts will be made (the original
+   * attempt, plus one retry).
+   */
+  retries?: number;
+
+  /**
+   * The maximum amount of time (in milliseconds) to wait for a response from
+   * the ShipEngine server.
+   *
+   * Defaults to 5000 (5 seconds).
+   */
+  timeout?: number;
+}
+```
+
 Methods
 -------------------------------
 * [`createLabelFromRate`](./docs/create-label-from-rate.md) - When retrieving rates for shipments using the `getRatesWithShipmentDetails` method, the returned information contains a `rateId` property that can be used to purchase a label without having to refill in the shipment information repeatedly.

--- a/src/config.ts
+++ b/src/config.ts
@@ -48,7 +48,7 @@ export interface ShipEngineConfig {
    * The maximum amount of time (in milliseconds) to wait for a response from
    * the ShipEngine server.
    *
-   * Defaults to 5000 (5 seconds).
+   * Defaults to 65000 (1 minute & 5 seconds).
    */
   timeout?: number;
 }
@@ -113,7 +113,7 @@ export class NormalizedConfig {
 
     // Retries
     if (config.retries === undefined) {
-      this.retries = 1;
+      this.retries = 0;
     } else {
       assert.isNonNegativeInteger("Retries", config.retries);
       this.retries = config.retries;
@@ -121,7 +121,7 @@ export class NormalizedConfig {
 
     // Timeout
     if (config.timeout === undefined) {
-      this.timeout = 5000;
+      this.timeout = 65000;
     } else {
       assert.isPositiveInteger("Timeout", config.timeout);
       this.timeout = config.timeout;


### PR DESCRIPTION
## SDK Modifications / Improvements Thirty Madison

This PR addresses a few things that have been making things hard for users when using the JS SDK. It adjusts the default values for `retries` `timeout` in `src/config.ts` to more sensible values given the high-level users we have with bespoke workflows. This allows them to change this to meet their needs rather than us making hard recommendations or assumptions about their workflow.

## Type of change
- [x] Fix

## JIRA
[SE-120 | SDK Modifications / Improvements Thirty Madison](https://auctane.atlassian.net/browse/SE-120)

## Acceptance Criteria
- [x] The `retries` default has been updated from `1` to `0`.
- [x] The `timeout` default has been increased `5000` to `65000`.
- [x] An explicit reference to the `ShipEngine Config` interface has been added to the `README.md`

<br>
<img src="https://media.giphy.com/media/3HSzHiDUtNLhu/giphy.gif" alt="superman" width="100%" />