### PR TITLE
chore: Bump version for contributor changes to publish properly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shipengine",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "shipengine",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "Apache-2.0",
       "dependencies": {
         "abort-controller": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shipengine",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "The official ShipEngine JavaScript SDK for Node.js",
   "keywords": [
     "shipengine",


### PR DESCRIPTION
## Bumping version for contributor publish

- This PR manually bumps the version in the package.json to fix a previously failed CI attempt to publish. While we troubleshoot the CI issue where it is not bumping the version properly, this will allow for a successful publish upon merging into main.

