### PR TITLE
Added error codes for funding sources errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### [1.0.8](https://www.github.com/ShipEngine/shipengine-js/compare/v1.0.7...v1.0.8) (2024-01-31)
+
+
+### Features
+
+* Added error code FundingSourceMissingConfiguration
+* Added error code FundingSourceError
+
 ### [1.0.7](https://www.github.com/ShipEngine/shipengine-js/compare/v1.0.6...v1.0.7) (2024-01-31)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shipengine",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "shipengine",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "Apache-2.0",
       "dependencies": {
         "abort-controller": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shipengine",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "The official ShipEngine JavaScript SDK for Node.js",
   "keywords": [
     "shipengine",

--- a/src/constants/error-code.ts
+++ b/src/constants/error-code.ts
@@ -38,4 +38,6 @@ export type ErrorCode =
   | "unspecified"
   | "verification_failure"
   | "warehouse_conflict"
-  | "webhook_event_type_conflict";
+  | "webhook_event_type_conflict"
+  | "funding_source_missing_configuration"
+  | "funding_source_error";

--- a/src/constants/error-type.ts
+++ b/src/constants/error-type.ts
@@ -9,4 +9,6 @@ export type ErrorType =
   | "security"
   | "validation"
   | "business_rules"
-  | "system";
+  | "system"
+  | "wallet"
+  | "funding_sources";


### PR DESCRIPTION
There are some common errors while interacting with funding sources that are not handled correctly. Two of them are that when we throw a PreSetupWalletException or a WalletException we return a "An unexpected error occurred" instead of a more understandable error.
JIRA: https://auctane.atlassian.net/browse/ENGINE-7190
ShipEngine: https://github.com/shipstation/shipstation/pull/20482
SE Documentation: https://github.com/ShipEngine/shipengine-api-definition/pull/114